### PR TITLE
fix parallel loop

### DIFF
--- a/src/calc_sum_squares_latent.cpp
+++ b/src/calc_sum_squares_latent.cpp
@@ -7,7 +7,6 @@
 // [[Rcpp::depends(RcppThread)]]
 #include "RcppThread.h"
 #include <cmath>
-#include <atomic>
 
 using namespace Rcpp ;
 
@@ -26,9 +25,6 @@ NumericVector calc_sum_squares_latent(
   NumericVector result(2); // final result
   arma::vec SSE(n_obs); // sum of squared errors across all documents
   arma::vec SST(n_obs); // total sum of squares across all documents
-
-  // convert R equivalent classes to arma classes
-
 
   // // for each observations...
   RcppThread::parallelFor(

--- a/src/calc_sum_squares_latent.cpp
+++ b/src/calc_sum_squares_latent.cpp
@@ -7,6 +7,7 @@
 // [[Rcpp::depends(RcppThread)]]
 #include "RcppThread.h"
 #include <cmath>
+#include <atomic>
 
 using namespace Rcpp ;
 
@@ -23,8 +24,8 @@ NumericVector calc_sum_squares_latent(
 
   int n_obs = Y.n_cols; // number of observations
   NumericVector result(2); // final result
-  double SSE = 0; // sum of squared errors across all documents
-  double SST = 0; // total sum of squares across all documents
+  std::atomic<double> SSE{ 0 }; // sum of squared errors across all documents
+  std::atomic<double> SST{ 0 }; // total sum of squares across all documents
 
 
   // convert R equivalent classes to arma classes

--- a/src/calc_sum_squares_latent.cpp
+++ b/src/calc_sum_squares_latent.cpp
@@ -24,14 +24,13 @@ NumericVector calc_sum_squares_latent(
 
   int n_obs = Y.n_cols; // number of observations
   NumericVector result(2); // final result
-  std::atomic<double> SSE{ 0 }; // sum of squared errors across all documents
-  std::atomic<double> SST{ 0 }; // total sum of squares across all documents
-
+  arma::vec SSE(n_obs); // sum of squared errors across all documents
+  arma::vec SST(n_obs); // total sum of squares across all documents
 
   // convert R equivalent classes to arma classes
 
 
-  // for each observations...
+  // // for each observations...
   RcppThread::parallelFor(
     0,
     n_obs,
@@ -61,15 +60,14 @@ NumericVector calc_sum_squares_latent(
 
       }
 
-      SSE = SSE + sse;
+      SSE(d) = sse;
 
-      SST = SST + sst;
+      SST(d) = sst;
     },
     threads);
 
-
-  result[ 0 ] = SSE;
-  result[ 1 ] = SST;
+  result[ 0 ] = sum(SSE);
+  result[ 1 ] = sum(SST);
 
   return result;
 


### PR DESCRIPTION
Noticed this during reverse dependency checks. The variables `SSE` and `SST` are shared across threads. This can cause problems if multiple threads read/write it at the same time. This fix should make it safe without causing much overhead.